### PR TITLE
Add sorting tier for "external-child" modules

### DIFF
--- a/docs/rules/import-order.md
+++ b/docs/rules/import-order.md
@@ -9,13 +9,15 @@ var path = require('path');
 // 2. "external" modules
 var _ = require('lodash');
 var chalk = require('chalk');
-// 3. modules from a "parent" directory
+// 3. "external-child" modules, references to non-root parts of modules
+var each = require('lodash/collection/each');
+// 4. modules from a "parent" directory
 var foo = require('../foo');
 var qux = require('../../foo/qux');
-// 4. "sibling" modules from the same or a sibling's directory
+// 5. "sibling" modules from the same or a sibling's directory
 var bar = require('./bar');
 var baz = require('./bar/baz');
-// 5. "index" of the current directory
+// 6. "index" of the current directory
 var main = require('./');
 ```
 
@@ -57,10 +59,10 @@ var path = require('path');
 
 This rule supports the following options:
 
-`order`: The order to respect. It needs to contain only and all of the following elements: `"builtin", "external", "parent", "sibling", "index"`, which is the default value.
+`order`: The order to respect. It can contain any and all of the following elements: `"builtin", "external", "external-child", "parent", "sibling", "index"`, which is the default value.
 
 You can set the options like this:
 
 ```js
-"import-order/import-order": [2, {"order": ["index", "sibling", "parent", "external", "builtin"]}]
+"import-order/import-order": [2, {"order": ["index", "sibling", "parent", "external-child", "external", "builtin"]}]
 ```

--- a/rules/import-order.js
+++ b/rules/import-order.js
@@ -3,7 +3,7 @@
 var find = require('lodash.find');
 var utils = require('../utils');
 
-var defaultOrder = ['builtin', 'external', 'parent', 'sibling', 'index'];
+var defaultOrder = ['builtin', 'external', 'external-child', 'parent', 'sibling', 'index'];
 
 // REPORTING
 

--- a/rules/import-order.js
+++ b/rules/import-order.js
@@ -85,7 +85,27 @@ function isInVariableDeclarator(node) {
 module.exports = function importOrderRule(context) {
   var imported = [];
   var options = context.options[0] || {};
-  var order = options.order || defaultOrder;
+
+  var order = (options.order || []).slice();
+  for (var i = 0, len = defaultOrder.length; i < len; i++) {
+    var name = defaultOrder[i];
+    var index = order.indexOf(name);
+
+    // If the tier is already present, don't mess with it.
+    if (~index) {
+      continue;
+    }
+
+    // Check if this is a child tier.
+    var parentMatch = name.match(/^([^-]+)-/);
+    // If so, locate its parent tier.
+    var parentIndex = parentMatch ? order.indexOf(parentMatch[1]) : -1;
+    // If the parent tier is found, insert child immediately after parent tier.
+    // Otherwise, insert at list end.
+    var spliceLocation = ~parentIndex ? parentIndex + 1 : order.length;
+    order.splice(spliceLocation, 0, name);
+  }
+
   var level = 0;
 
   function incrementLevel() {

--- a/test/import-order.js
+++ b/test/import-order.js
@@ -62,10 +62,11 @@ test(() => {
           var relParent3 = require('../');
           var relParent2 = require('../foo/bar');
           var relParent1 = require('../foo');
+          var parseColor = require('util/parseColor');
           var async = require('async');
           var fs = require('fs');
         `,
-        options: [{order: ['index', 'sibling', 'parent', 'external', 'builtin']}]
+        options: [{order: ['index', 'sibling', 'parent', 'external-child', 'external', 'builtin']}]
       },
       // Ignore dynamic requires
       `

--- a/test/import-order.js
+++ b/test/import-order.js
@@ -223,7 +223,7 @@ test(() => {
           var fs = require('fs');
           var index = require('./');
         `,
-        options: [{order: ['index', 'sibling', 'parent', 'external', 'builtin']}],
+        options: [{order: ['index', 'builtin']}],
         errors: [
           {...ruleError, message: '`./` import should occur before import of `fs`'}
         ]
@@ -247,6 +247,16 @@ test(() => {
         errors: [
           {...ruleError, message: '`fs` import should occur before import of `./foo`'}
         ]
+      },
+      // Overriding order should maintain implicit ordering between external and external-child modules
+      {
+        code: `
+        var fooBar = require('foo/bar');
+        var foo = require('foo');
+        var fs = require('fs');
+        `,
+        options: [{order: ['external', 'builtin']}],
+        errors: [{...ruleError, message: '`foo` import should occur before import of `foo/bar`'}]
       }
     ]
   });

--- a/test/importType.js
+++ b/test/importType.js
@@ -18,13 +18,13 @@ test('should return "external-child" for non-builtin modules with path separator
   t.is(importType('utils/parseColor'), 'external-child');
 });
 
-test('should return parent for internal modules that go through the parent', t => {
+test('should return "parent" for internal modules that go through the parent', t => {
   t.is(importType('../foo'), 'parent');
   t.is(importType('../../foo'), 'parent');
   t.is(importType('../bar/foo'), 'parent');
 });
 
-test('should return sibling for internal modules that are connected to one of the siblings', t => {
+test('should return "sibling" for internal modules that are connected to one of the siblings', t => {
   t.is(importType('./foo'), 'sibling');
   t.is(importType('./foo/bar'), 'sibling');
 });

--- a/test/importType.js
+++ b/test/importType.js
@@ -14,6 +14,10 @@ test('should return "external" for non-builtin modules without a relative path',
   t.is(importType('lodash.find'), 'external');
 });
 
+test('should return "external-child" for non-builtin modules with path separators', t => {
+  t.is(importType('utils/parseColor'), 'external-child');
+});
+
 test('should return parent for internal modules that go through the parent', t => {
   t.is(importType('../foo'), 'parent');
   t.is(importType('../../foo'), 'parent');

--- a/utils.js
+++ b/utils.js
@@ -13,9 +13,14 @@ function isBuiltIn(name) {
   return builtinModules.indexOf(name) !== -1;
 }
 
-var externalModuleRegExp = /^\w/;
+var externalModuleRegExp = /^\w[^\/]*$/;
 function isExternalModule(name) {
   return externalModuleRegExp.test(name);
+}
+
+var externalChildModuleRegExp = /^[^\.][^\/]*\//;
+function isExternalChildModule(name) {
+  return externalChildModuleRegExp.test(name);
 }
 
 function isRelativeToParent(name) {
@@ -36,6 +41,7 @@ function isRelativeToSibling(name) {
 var importType = cond([
   [isBuiltIn, constant('builtin')],
   [isExternalModule, constant('external')],
+  [isExternalChildModule, constant('external-child')],
   [isRelativeToParent, constant('parent')],
   [isIndex, constant('index')],
   [isRelativeToSibling, constant('sibling')],


### PR DESCRIPTION
Often project-specific modules are referenced using "absolute" paths like `utils/color/parseColor`. Currently, `import-order` interprets these as "external" references. Instead, I'd like for them to live at their own tier between "external" and "parent" references.
