### PR TITLE
Add `no-extraneous-dependencies` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ Configure it in `package.json`.
 			"import-order"
 		],
 		"rules": {
-			"import-order/import-order": 2
+			"import-order/import-order": "error",
+			"import-order/no-extraneous-dependencies": "error"
 		}
 	}
 }
@@ -41,6 +42,7 @@ Configure it in `package.json`.
 ## Rules
 
 - [import-order](docs/rules/import-order.md) - Enforce a convention in module import order.
+- [no-extraneous-dependencies](docs/rules/no-extraneous-dependencies.md) - Forbid the use of extraneous packages.
 
 ## Recommended configuration
 

--- a/docs/rules/import-order.md
+++ b/docs/rules/import-order.md
@@ -62,5 +62,5 @@ This rule supports the following options:
 You can set the options like this:
 
 ```js
-"import-order/import-order": [2, {"order": ["index", "sibling", "parent", "external", "builtin"]}]
+"import-order/import-order": ["error", {"order": ["index", "sibling", "parent", "external", "builtin"]}]
 ```

--- a/docs/rules/no-extraneous-dependencies.md
+++ b/docs/rules/no-extraneous-dependencies.md
@@ -1,0 +1,59 @@
+# Forbid the use of extraneous packages
+
+Forbid the import of external modules that are not declared in the `package.json`'s `dependencies` or `devDependencies`.
+If no `package.json` is found, the rule will not lint anything.
+
+For the following examples, let's consider the following `package.json`:
+```json
+{
+  "name": "my-project",
+  "...": "...",
+  "devDependencies": {
+    "ava": "^0.13.0",
+    "eslint": "^2.4.0",
+    "eslint-plugin-ava": "^1.3.0",
+    "xo": "^0.13.0"
+  },
+  "dependencies": {
+    "builtin-modules": "^1.1.1",
+    "lodash.cond": "^4.2.0",
+    "lodash.find": "^4.2.0",
+    "pkg-up": "^1.0.0"
+  }
+}
+```
+
+## Fail
+
+```js
+var _ = require('lodash');
+import _ from 'lodash';
+
+/* eslint import-order/no-extraneous-dependencies: ["error", {"devDependencies": false}] */
+import test from 'ava';
+var test = require('ava');
+```
+
+
+## Pass
+
+```js
+// Non-external modules are fine
+var path = require('path');
+var foo = require('./foo');
+
+import test from 'ava';
+import find from 'lodash.find';
+```
+
+## Options
+
+This rule supports the following options:
+
+`devDependencies`: If set to `false`, then `devDependencies` are not allowed. Defaults to `true`.
+
+You can set the options like this:
+
+```js
+"import-order/no-extraneous-dependencies": ["error", {"devDependencies": false}]
+```

--- a/index.js
+++ b/index.js
@@ -2,7 +2,8 @@
 
 module.exports = {
   rules: {
-    'import-order': require('./rules/import-order')
+    'import-order': require('./rules/import-order'),
+    'no-extraneous-dependencies': require('./rules/no-extraneous-dependencies')
   },
   configs: {
     recommended: {
@@ -14,7 +15,8 @@ module.exports = {
         sourceType: 'module'
       },
       rules: {
-        'import-order/import-order': 2
+        'import-order/import-order': 'error',
+        'import-order/no-extraneous-dependencies': 'error'
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
   "dependencies": {
     "builtin-modules": "^1.1.1",
     "lodash.cond": "^4.2.0",
-    "lodash.find": "^4.2.0"
+    "lodash.find": "^4.2.0",
+    "pkg-up": "^1.0.0"
   },
   "xo": {
     "space": 2,

--- a/rules/import-order.js
+++ b/rules/import-order.js
@@ -57,14 +57,6 @@ function makeReport(context, imported) {
 
 // DETECTING
 
-function isStaticRequire(node) {
-  return node &&
-    node.callee.type === 'Identifier' &&
-    node.callee.name === 'require' &&
-    node.arguments.length === 1 &&
-    node.arguments[0].type === 'Literal';
-}
-
 function computeRank(order, name) {
   return order.indexOf(utils.importType(name));
 }
@@ -103,7 +95,7 @@ module.exports = function importOrderRule(context) {
       }
     },
     CallExpression: function handleRequires(node) {
-      if (level !== 0 || !isStaticRequire(node) || !isInVariableDeclarator(node.parent)) {
+      if (level !== 0 || !utils.isStaticRequire(node) || !isInVariableDeclarator(node.parent)) {
         return;
       }
       var name = node.arguments[0].value;

--- a/rules/no-extraneous-dependencies.js
+++ b/rules/no-extraneous-dependencies.js
@@ -1,0 +1,75 @@
+var fs = require('fs');
+var pkgUp = require('pkg-up');
+var utils = require('../utils');
+
+function getDependencies() {
+  var filepath = pkgUp.sync();
+  if (!filepath) {
+    return null;
+  }
+
+  try {
+    var packageContent = JSON.parse(fs.readFileSync(filepath, 'utf8'));
+    return {
+      dependencies: packageContent.dependencies || {},
+      devDependencies: packageContent.devDependencies || {}
+    };
+  } catch (e) {
+    return null;
+  }
+}
+
+function missingErrorMessage(packageName) {
+  return '`' + packageName + '` is not listed in the project\'s dependencies. ' +
+    'Run `npm i -S ' + packageName + '` to add it';
+}
+
+function devDepErrorMessage(packageName) {
+  return '`' + packageName + '` should be listed in your project\'s dependencies, not devDependencies.';
+}
+
+function reportIfMissing(context, deps, allowDevDeps, node, name) {
+  if (utils.importType(name) !== 'external') {
+    return;
+  }
+  var packageName = name.split('/')[0];
+
+  if (deps.dependencies[packageName] === undefined) {
+    if (!allowDevDeps) {
+      context.report(node, devDepErrorMessage(packageName));
+    } else if (deps.devDependencies[packageName] === undefined) {
+      context.report(node, missingErrorMessage(packageName));
+    }
+  }
+}
+
+module.exports = function (context) {
+  var options = context.options[0] || {};
+  var allowDevDeps = options.devDependencies !== false;
+  var deps = getDependencies();
+
+  if (!deps) {
+    return {};
+  }
+
+  return {
+    ImportDeclaration: function (node) {
+      reportIfMissing(context, deps, allowDevDeps, node, node.source.value);
+    },
+    CallExpression: function handleRequires(node) {
+      if (utils.isStaticRequire(node)) {
+        reportIfMissing(context, deps, allowDevDeps, node, node.arguments[0].value);
+      }
+    }
+  };
+};
+
+module.exports.schema = [
+  {
+    type: 'object',
+    properties: {
+      devDependencies: {type: 'boolean'}
+    },
+    additionalProperties: false
+  }
+];

--- a/test/importType.js
+++ b/test/importType.js
@@ -12,6 +12,7 @@ test('should return "external" for non-builtin modules without a relative path',
   t.is(importType('chalk'), 'external');
   t.is(importType('foo'), 'external');
   t.is(importType('lodash.find'), 'external');
+  t.is(importType('lodash/fp'), 'external');
 });
 
 test('should return parent for internal modules that go through the parent', t => {

--- a/test/no-extraneous-dependencies.js
+++ b/test/no-extraneous-dependencies.js
@@ -1,0 +1,64 @@
+import test from 'ava';
+import {RuleTester} from 'eslint';
+import rule from '../rules/no-extraneous-dependencies';
+
+const ruleTester = new RuleTester({
+  env: {
+    es6: true
+  },
+  parserOptions: {
+    sourceType: 'module'
+  }
+});
+
+test(() => {
+  ruleTester.run('no-extraneous-dependencies', rule, {
+    valid: [
+      `import 'lodash.find'`,
+      `import 'pkg-up'`,
+      `import foo, { bar } from 'lodash.find'`,
+      `import foo, { bar } from 'pkg-up'`,
+      `import 'eslint'`,
+      `import 'eslint/lib/api'`,
+
+      `require('lodash.find')`,
+      `require('pkg-up')`,
+      `var foo = require('lodash.find')`,
+      `var foo = require('pkg-up')`,
+      `import 'fs'`,
+      `import './foo'`
+    ],
+    invalid: [
+      {
+        code: `import 'not-a-dependency'`,
+        errors: [{
+          ruleId: 'no-extraneous-dependencies',
+          message: '`not-a-dependency` is not listed in the project\'s dependencies. Run `npm i -S not-a-dependency` to add it'
+        }]
+      },
+      {
+        code: `import 'eslint'`,
+        options: [{devDependencies: false}],
+        errors: [{
+          ruleId: 'no-extraneous-dependencies',
+          message: '`eslint` should be listed in your project\'s dependencies, not devDependencies.'
+        }]
+      },
+      {
+        code: `var foo = require('not-a-dependency');`,
+        errors: [{
+          ruleId: 'no-extraneous-dependencies',
+          message: '`not-a-dependency` is not listed in the project\'s dependencies. Run `npm i -S not-a-dependency` to add it'
+        }]
+      },
+      {
+        code: `var eslint = require('eslint');`,
+        options: [{devDependencies: false}],
+        errors: [{
+          ruleId: 'no-extraneous-dependencies',
+          message: '`eslint` should be listed in your project\'s dependencies, not devDependencies.'
+        }]
+      }
+    ]
+  });
+});

--- a/utils.js
+++ b/utils.js
@@ -42,6 +42,15 @@ var importType = cond([
   [constant(true), constant('unknown')]
 ]);
 
+function isStaticRequire(node) {
+  return node &&
+    node.callee.type === 'Identifier' &&
+    node.callee.name === 'require' &&
+    node.arguments.length === 1 &&
+    node.arguments[0].type === 'Literal';
+}
+
 module.exports = {
-  importType: importType
+  importType: importType,
+  isStaticRequire: isStaticRequire
 };


### PR DESCRIPTION
Adds `no-extraneous-dependencies` rule

As noted https://github.com/benmosher/eslint-plugin-import/issues/126#issuecomment-209052027 (under `Regarding resolution`) here, some additional work needs to be done to ignore internal modules when accessed with external module-like paths (see the comment for an example).

As that seems to me like it's not a wide-spread practice, I will create an issue to implement that later. For now, this should suit the common case.

@kentcdodds @benmosher If you have some feedback for this, I'd appreciate it :)

I'm not sure whether this will land in the `eslint-plugin-import-order` or if I create a new package/fork of the repo with a more generic name (`eslint-plugin-import-rules`... ? :s), cc @sindresorhus.
