### PR TITLE
`order` accepts regular expressions. Add `alphabetize` option.

### DIFF
--- a/docs/rules/import-order.md
+++ b/docs/rules/import-order.md
@@ -57,10 +57,18 @@ var path = require('path');
 
 This rule supports the following options:
 
-`order`: The order to respect. It needs to contain only and all of the following elements: `"builtin", "external", "parent", "sibling", "index"`, which is the default value.
+`order`: The order to respect. The default order is `"builtin", "external", "parent", "sibling", "index"`. It may be overriden with an array containing any or all of these values. Any value from the default list not appearing in an explicit ordering are appended to the provided list.
 
 You can set the options like this:
 
 ```js
 "import-order/import-order": [2, {"order": ["index", "sibling", "parent", "external", "builtin"]}]
+```
+
+Additionally, you may supply regular expressions within this list, against which import paths will be tested. Paths not matching any rule are subject to the default sorting rules, and are sorted after the regular expression-based rules.
+
+`alphabetize`: Whether to enforce alphabetization of imports within a single sort group. For example, while all `"builtin"` modules must appear before `"external"` modules, this rule will enforce that all `"builtin"` rules are sorted alphabetically with respect to one another.
+
+```js
+"import-order/import-order": [2, {"alphabetize": true}]
 ```

--- a/rules/import-order.js
+++ b/rules/import-order.js
@@ -36,7 +36,8 @@ function report(context, imported, outOfOrder, order) {
     var found = find(imported, function hasHigherRank(importedItem) {
       return importedItem.rank > imp.rank;
     });
-    context.report(imp.node, '`' + imp.name + '` import should occur ' + order + ' import of `' + found.name + '`');
+    var message = '`' + imp.name + '` import should occur ' + order + ' import of `' + found.name + '`';
+    context.report(imp.node, message);
   });
 }
 
@@ -55,6 +56,34 @@ function makeReport(context, imported) {
   report(context, imported, outOfOrder, 'before');
 }
 
+// Flatten the array-of-array buckets structure.
+function rankBuckets(buckets, options) {
+  if (options.alphabetize) {
+    buckets.forEach(function (bucket) {
+      bucket.sort(function (a, b) {
+        return a.name < b.name ? -1 : 1;
+      });
+    });
+  }
+
+  // Flatten bucket and append to final order list.
+  buckets.reduce(function (acc, bucket) {
+    if (bucket && bucket.length) {
+      var len = acc.length;
+
+      bucket.forEach(function (data, i) {
+        // Annotate rank.
+        data.rank = len + i;
+      });
+
+      // Append imports.
+      acc = acc.concat(bucket);
+    }
+
+    return acc;
+  }, []);
+}
+
 // DETECTING
 
 function isStaticRequire(node) {
@@ -65,14 +94,25 @@ function isStaticRequire(node) {
     node.arguments[0].type === 'Literal';
 }
 
-function computeRank(order, name) {
-  return order.indexOf(utils.importType(name));
+function computeBucket(order, name) {
+  var regExp = find(order, function (o) {
+    return o.test && o.test(name);
+  });
+
+  // Buckets numbers are cardinal.
+  return order.indexOf(regExp || utils.importType(name));
 }
 
-function registerNode(node, name, order, imported) {
-  var rank = computeRank(order, name);
-  if (rank !== -1) {
-    imported.push({name: name, rank: rank, node: node});
+function registerNode(node, name, order, imported, buckets) {
+  // Each node will fall into a single bucket, and may optionally be sorted
+  // within that bucket.
+  var bucket = computeBucket(order, name);
+
+  if (~bucket) {
+    var data = {name: name, node: node};
+    buckets[bucket] = buckets[bucket] || [];
+    buckets[bucket].push(data);
+    imported.push(data);
   }
 }
 
@@ -81,11 +121,36 @@ function isInVariableDeclarator(node) {
     (node.type === 'VariableDeclarator' || isInVariableDeclarator(node.parent));
 }
 
+function getOrder(options) {
+    // Clone any explicitly-provided order tiers.
+  var order = options.order ? options.order.slice() : [];
+
+  // Loop through the default tiers, checking to see if they already exist
+  // within the explicitly-provided tiers.
+  for (var i = 0, len = defaultOrder.length; i < len; i++) {
+    var name = defaultOrder[i];
+    var index = order.indexOf(name);
+
+    // If the tier is not already present, append it to the list.
+    if (!~index) {
+      order.push(name);
+    }
+  }
+
+  return order;
+}
+
 /* eslint quote-props: [2, "as-needed"] */
 module.exports = function importOrderRule(context) {
-  var imported = [];
   var options = context.options[0] || {};
-  var order = options.order || defaultOrder;
+
+  // buckets are numbered, order is important.
+  var buckets = [];
+  // List of all recognized imports, in order of actual occurrence.
+  var imported = [];
+
+  var order = getOrder(options);
+
   var level = 0;
 
   function incrementLevel() {
@@ -99,7 +164,7 @@ module.exports = function importOrderRule(context) {
     ImportDeclaration: function handleImports(node) {
       if (node.specifiers.length) { // Ignoring unassigned imports
         var name = node.source.value;
-        registerNode(node, name, order, imported);
+        registerNode(node, name, order, imported, buckets);
       }
     },
     CallExpression: function handleRequires(node) {
@@ -107,11 +172,12 @@ module.exports = function importOrderRule(context) {
         return;
       }
       var name = node.arguments[0].value;
-      registerNode(node, name, order, imported);
+      registerNode(node, name, order, imported, buckets);
     },
     'Program:exit': function reportAndReset() {
+      rankBuckets(buckets, options);
       makeReport(context, imported);
-      imported = [];
+      buckets = [];
     },
     FunctionDeclaration: incrementLevel,
     FunctionExpression: incrementLevel,
@@ -129,12 +195,10 @@ module.exports.schema = [
     type: 'object',
     properties: {
       order: {
-        type: 'array',
-        uniqueItems: true,
-        length: 5,
-        items: {
-          enum: defaultOrder
-        }
+        type: 'array'
+      },
+      alphabetize: {
+        type: 'boolean'
       }
     },
     additionalProperties: false

--- a/test/import-order.js
+++ b/test/import-order.js
@@ -67,6 +67,24 @@ test(() => {
         `,
         options: [{order: ['index', 'sibling', 'parent', 'external', 'builtin']}]
       },
+      // Overriding order to include a regular expression
+      {
+        code: `
+          var cond = require('lodash.cond');
+          var findIndex = require('lodash.find');
+          var path = require('path');
+          var $ = require('jquery');
+        `,
+        options: [{order: [/^lodash\./, 'builtin', /^jquery$/]}]
+      },
+      // Alphabetize by import path
+      {
+        code: `
+          var fs = require('fs');
+          var path = require('path');
+        `,
+        options: [{alphabetize: true}]
+      },
       // Ignore dynamic requires
       `
       var path = require('path');
@@ -225,6 +243,29 @@ test(() => {
         options: [{order: ['index', 'sibling', 'parent', 'external', 'builtin']}],
         errors: [
           {...ruleError, message: '`./` import should occur before import of `fs`'}
+        ]
+      },
+      // Overriding order to include a regular expression
+      {
+        code: `
+          var $ = require('jquery');
+          var cond = require('lodash.cond');
+          var findIndex = require('lodash.find');
+        `,
+        options: [{order: [/^lodash\./, /^jquery$/]}],
+        errors: [
+          {...ruleError, message: '`jquery` import should occur after import of `lodash.find`'}
+        ]
+      },
+      // Alphabetize by import path
+      {
+        code: `
+          var path = require('path');
+          var fs = require('fs');
+        `,
+        options: [{alphabetize: true}],
+        errors: [
+          {...ruleError, message: '`fs` import should occur before import of `path`'}
         ]
       },
       // member expression of require


### PR DESCRIPTION
This PR follows-on to #8 

I originally wrote the `external-submodules` functionality to try and enforce the loosely-followed rules already present in our large webpack-based codebase, but found the rough, pre-defined clustering of rules baked into the plugin to be too restricting to deal with what we were already doing.

To deal with this, I propose this backwards-compatible solution. Like #8 it supports partial orderings of the built-in ordering tiers. Unlike #8, it adds no new explicit tiers. Instead, it allows users to configure their own tiers using regular expressions, and to freely intermingle these regular expressions with the pre-defined tiers.

Additionally, it adds a new `alphabetize` option for sorting intra-tier modules which helps establish a truly canonical import ordering rather than just rough clustering.

Probably the biggest caveat with this PR is that it significantly relaxes the JSON schema requirements that were previously present, possibly opening an avenue to confusing misconfiguration.
